### PR TITLE
Support multi processing in Worker node

### DIFF
--- a/src/spaceone/core/scheduler/scheduler.py
+++ b/src/spaceone/core/scheduler/scheduler.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class BaseScheduler(Process):
-    def __init__(self, queue):
+    def __init__(self, queue, **kwargs):
         super().__init__()
         self.queue = queue
         self.config = None

--- a/src/spaceone/core/scheduler/server.py
+++ b/src/spaceone/core/scheduler/server.py
@@ -7,6 +7,7 @@ from spaceone.core.logger import set_logger
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_POOL = 8
 
 class Server(object):
     def __init__(self, service, config):
@@ -68,8 +69,14 @@ class Server(object):
             if 'queue' not in conf:
                 _LOGGER.debug('Queue is not specified')
                 # TODO: ERROR
+            # Support Worker pool (default: 8)
             # self.queue is instance of Queue
-            self.workers[name] = self._create_process(backend, params)
+            pool = params.get('pool', DEFAULT_POOL)
+            _LOGGER.debug(f'[start] create thread pool: {pool}')
+            for index in range(pool):
+                worker_name = f'{name}_{index}'
+                _LOGGER.debug(f'[start] create {worker_name}')
+                self.workers[worker_name] = self._create_process(backend, params)
 
         # Start All threads
         # start worker

--- a/src/spaceone/core/scheduler/worker.py
+++ b/src/spaceone/core/scheduler/worker.py
@@ -82,7 +82,7 @@ class SpaceoneTask:
 
 class BaseWorker(Process):
 
-    def __init__(self, queue):
+    def __init__(self, queue, **kwargs):
         super().__init__()
         self._name_ = 'worker-%s' % randomString()
         self.queue = queue


### PR DESCRIPTION
Worker can be multi processing.
Add pool keyword which is the number of multi processing.
Default value is 8.

Example config

      WORKERS:
        collector_worker:
          backend: spaceone.core.scheduler.worker.BaseWorker
          queue: collector_q
	  pool: 4

Signed-off-by: Choonho Son <choonhoson@megazone.com>