### PR TITLE
refactor: apply local storage when using transaction

### DIFF
--- a/src/spaceone/core/logger/filters/transaction.py
+++ b/src/spaceone/core/logger/filters/transaction.py
@@ -1,19 +1,19 @@
 import logging
+from spaceone.core.transaction import LOCAL_STORAGE
 
 
 class TransactionFilter(logging.Filter):
-    def __init__(self, transaction=None):
-        self.transaction = transaction
 
     def filter(self, record):
-        if self.transaction:
-            record.service = self.transaction.service
-            record.tnx_id = self.transaction.id
-            record.tnx_status = self.transaction.status
-            record.peer = self.transaction.get_meta('peer')
-
-            if self.transaction.resource and self.transaction.verb:
-                record.tnx_method = f'{self.transaction.resource}.{self.transaction.verb}'
+        transaction = getattr(LOCAL_STORAGE, 'transaction', None)
+        print(transaction)
+        if transaction:
+            record.service = transaction.service
+            record.tnx_id = transaction.id
+            record.tnx_status = transaction.status
+            record.peer = transaction.get_meta('peer')
+            if transaction.resource and transaction.verb:
+                record.tnx_method = f'{transaction.resource}.{transaction.verb}'
             else:
                 record.tnx_method = ''
         else:
@@ -22,5 +22,4 @@ class TransactionFilter(logging.Filter):
             record.tnx_status = ""
             record.tnx_method = ""
             record.peer = ""
-
         return True

--- a/src/spaceone/core/logger/filters/transaction.py
+++ b/src/spaceone/core/logger/filters/transaction.py
@@ -5,9 +5,7 @@ from spaceone.core.transaction import LOCAL_STORAGE
 class TransactionFilter(logging.Filter):
 
     def filter(self, record):
-        transaction = getattr(LOCAL_STORAGE, 'transaction', None)
-        print(transaction)
-        if transaction:
+        if transaction:= getattr(LOCAL_STORAGE, 'transaction', None):
             record.service = transaction.service
             record.tnx_id = transaction.id
             record.tnx_status = transaction.status

--- a/src/spaceone/core/service/service.py
+++ b/src/spaceone/core/service/service.py
@@ -8,7 +8,6 @@ import traceback
 from spaceone.core import config
 from spaceone.core.error import *
 from spaceone.core.locator import Locator
-from spaceone.core.logger import set_logger
 from spaceone.core.transaction import Transaction
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,9 +26,6 @@ class BaseService(object):
             self.transaction = transaction
         else:
             self.transaction = Transaction(metadata)
-
-        if config.get_global('SET_LOGGING', True):
-            set_logger(transaction=self.transaction)
 
         self.locator = Locator(self.transaction)
         self.handler = {

--- a/src/spaceone/core/transaction.py
+++ b/src/spaceone/core/transaction.py
@@ -2,8 +2,12 @@ import traceback
 import logging
 from spaceone.core import utils
 from spaceone.core.error import *
+from threading import local
+
+__all__ = ['LOCAL_STORAGE', 'Transaction']
 
 _LOGGER = logging.getLogger(__name__)
+LOCAL_STORAGE = local()
 
 
 class Transaction(object):
@@ -18,6 +22,8 @@ class Transaction(object):
         self._status = 'STARTED'
         self._set_transaction_id()
         self._event_handlers = []
+
+        LOCAL_STORAGE.transaction = self
 
     def __repr__(self):
         return f"<Transaction ({self.resource}.{self.verb})>"


### PR DESCRIPTION
< 문제 상황 >
* 쓰레드별 transaction을 모두 공유하고 있는 상황으로 쓰레드별 transaction을 같지 못함
* 기존 TransactionFilter의 초기화 부분에 transaction을 넣어주는 구조이기 때문에 BaseService에서 set_logger(transaction)과 같이 의존성을 가지는 문제가 발생
* gRPC 서버 구동시 1회만 logger setting을 하기 위해 BaseService의 set_logger를 제거하고 transaction 의존성 문제를 해결해야 함

< 해결 방안 >
* threading 모듈의 local을 이용해 각 쓰레드별 storage를 가질 수 있음
* local의 생명 주기는 쓰레드 소멸시 local도 소멸됨
* global로 선언된 local에 transaction을 주입하고 TransactionFIlter에서 local에 접근해 필요한 값을 공유받는 구조로 변경
* 아래 그림은 document에 있는 local의 설명으로 각 쓰레드별 storage를 갖는 것을 알 수 있음


![image](https://user-images.githubusercontent.com/83386688/148888705-2eacf786-d688-4afb-b3d4-999aab8f0cda.png)
